### PR TITLE
docs(common): Dark Mode Logos for Github PL #442

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ Proton will solve this problem by creating a namespace that works across multipl
 
 ## About Edenia
 
-<p align="center">
+<div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/165814672-9a7763a8-9748-405d-8bc0-de0278ce9eb4.png" width="300">
+		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
 	</a>
 </p>
-<br/>
+
+[![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
+![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=discord&logo=discord&logoColor=white&style=for-the-badge)
+
+</div>
 
 Edenia runs independent blockchain infrastructure and develops web3 solutions. Our team of technology-agnostic builders has been operating since 1987, leveraging the newest technologies to make the internet safer, more efficient, and more transparent.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 	<a href="#">
 		<img src="https://img.shields.io/dub/l/vibe-d.svg" alt="MIT">
 	</a>
-</p>
 
 ## Description
 This project builds the Proton network in a local environment so that testing can be done before being published on the public network.
@@ -106,9 +105,8 @@ Proton will solve this problem by creating a namespace that works across multipl
 
 <div align="center">
 	<a href="https://edenia.com">
-		<img src="https://user-images.githubusercontent.com/5632966/178800854-cffb01ea-b55a-44b2-bcfa-872301874a43.png" width="300">
+		<img src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png" width="300">
 	</a>
-</p>
 
 [![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
 ![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=discord&logo=discord&logoColor=white&style=for-the-badge)


### PR DESCRIPTION
Changed logo for it to be visible in dark mode

### What does this PR do?

- resolves https://github.com/eoscostarica/guide.eoscostarica.io/issues/442

### Steps to test
1. Scroll to bottom of readme and see applied logo

#### CheckList
- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
